### PR TITLE
Fix drag selection freeze

### DIFF
--- a/DYYYFilterSettingsView.m
+++ b/DYYYFilterSettingsView.m
@@ -246,7 +246,6 @@ static const int kDYYYButtonsPerRow = 10;
     self.isDragging = YES;
 
     if (self.selectedRange.location != NSNotFound) {
-      [self resetSelection];
       self.isSelecting = YES;
       self.startIndex = self.touchDownIndex;
       self.endIndex = self.touchDownIndex;
@@ -360,7 +359,6 @@ static const int kDYYYButtonsPerRow = 10;
     self.startIndex = -1;
     self.endIndex = -1;
     self.selectedText = [NSMutableString string];
-    self.touchDownIndex = -1;
     self.selectedRange = NSMakeRange(NSNotFound, 0);
     
     UIColor *buttonBackgroundColor = DYYYColor(

--- a/DYYYFilterSettingsView.m
+++ b/DYYYFilterSettingsView.m
@@ -1,6 +1,18 @@
 #import "DYYYFilterSettingsView.h"
 #import "DYYYManager.h"
 
+static inline UIColor *DYYYAccentColor(void) {
+  return [UIColor colorWithRed:11 / 255.0 green:223 / 255.0 blue:154 / 255.0 alpha:1.0];
+}
+
+static inline UIColor *DYYYColor(UIColor *darkColor, UIColor *lightColor, BOOL darkMode) {
+  return darkMode ? darkColor : lightColor;
+}
+
+static const CGFloat kDYYYButtonSize = 25.0;
+static const CGFloat kDYYYButtonMargin = 1.0;
+static const int kDYYYButtonsPerRow = 10;
+
 @interface DYYYFilterSettingsView ()
 
 @property(nonatomic, strong) UIVisualEffectView *blurView;
@@ -18,6 +30,10 @@
 @property(nonatomic, assign) NSInteger endIndex;
 @property(nonatomic, strong) NSMutableString *selectedText;
 @property(nonatomic, assign) BOOL isSelecting;
+@property(nonatomic, assign) BOOL isDragging;
+@property(nonatomic, assign) NSInteger touchDownIndex;
+@property(nonatomic, assign) BOOL darkMode;
+@property(nonatomic, assign) NSRange selectedRange;
 
 @end
 
@@ -31,27 +47,31 @@
     _startIndex = -1;
     _endIndex = -1;
     _isSelecting = NO;
+    _isDragging = NO;
+    _touchDownIndex = -1;
+    _selectedRange = NSMakeRange(NSNotFound, 0);
     
     self.backgroundColor = [UIColor colorWithWhite:0 alpha:0.2];
 
-    BOOL isDarkMode = [DYYYManager isDarkMode];
+    self.darkMode = [DYYYManager isDarkMode];
 
     // 创建模糊背景视图
     self.blurView = [[UIVisualEffectView alloc]
-        initWithEffect:[UIBlurEffect effectWithStyle:isDarkMode
+        initWithEffect:[UIBlurEffect effectWithStyle:self.darkMode
                                           ? UIBlurEffectStyleDark
                                           : UIBlurEffectStyleLight]];
     self.blurView.frame = self.bounds;
-    self.blurView.alpha = isDarkMode ? 0.3 : 0.2;
+    self.blurView.alpha = self.darkMode ? 0.3 : 0.2;
     [self addSubview:self.blurView];
 
     // 创建内容视图 - 根据模式设置背景色
     self.contentView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 300, 400)];
     CGFloat screenHeight = UIScreen.mainScreen.bounds.size.height;
     self.contentView.center = CGPointMake(self.frame.size.width / 2, screenHeight / 3);
-    self.contentView.backgroundColor = isDarkMode ?
-        [UIColor colorWithRed:30/255.0 green:30/255.0 blue:30/255.0 alpha:1.0] :
-        [UIColor whiteColor];
+    self.contentView.backgroundColor = DYYYColor(
+        [UIColor colorWithRed:30/255.0 green:30/255.0 blue:30/255.0 alpha:1.0],
+        [UIColor whiteColor],
+        self.darkMode);
     self.contentView.layer.cornerRadius = 12;
     self.contentView.layer.masksToBounds = YES;
     self.contentView.alpha = 0;
@@ -61,9 +81,10 @@
     // 主标题 - 根据模式设置文本颜色
     self.titleLabel = [[UILabel alloc] initWithFrame:CGRectMake(20, 20, 260, 24)];
     self.titleLabel.text = title ?: @"推荐过滤设置";
-    self.titleLabel.textColor = isDarkMode ?
-        [UIColor colorWithRed:230/255.0 green:230/255.0 blue:235/255.0 alpha:1.0] :
-        [UIColor colorWithRed:45/255.0 green:47/255.0 blue:56/255.0 alpha:1.0];
+    self.titleLabel.textColor = DYYYColor(
+        [UIColor colorWithRed:230/255.0 green:230/255.0 blue:235/255.0 alpha:1.0],
+        [UIColor colorWithRed:45/255.0 green:47/255.0 blue:56/255.0 alpha:1.0],
+        self.darkMode);
     self.titleLabel.textAlignment = NSTextAlignmentCenter;
     self.titleLabel.font = [UIFont systemFontOfSize:18 weight:UIFontWeightMedium];
     [self.contentView addSubview:self.titleLabel];
@@ -72,29 +93,31 @@
     self.keywordFilterButton = [UIButton buttonWithType:UIButtonTypeSystem];
     self.keywordFilterButton.frame = CGRectMake(240, 20, 40, 24);
     [self.keywordFilterButton setImage:[UIImage systemImageNamed:@"line.3.horizontal.decrease.circle"] forState:UIControlStateNormal];
-    self.keywordFilterButton.tintColor = [UIColor colorWithRed:11/255.0 green:223/255.0 blue:154/255.0 alpha:1.0]; // #0BDF9A 保持不变
+    self.keywordFilterButton.tintColor = DYYYAccentColor();
     [self.keywordFilterButton addTarget:self action:@selector(keywordFilterTapped) forControlEvents:UIControlEventTouchUpInside];
     [self.contentView addSubview:self.keywordFilterButton];
 
     // 选中预览区域 - 根据模式设置背景色
     self.selectionPreviewLabel = [[UILabel alloc] initWithFrame:CGRectMake(20, 54, 260, 50)];
     self.selectionPreviewLabel.text = @"请滑动选择文字";
-    self.selectionPreviewLabel.textColor = [UIColor colorWithRed:11/255.0 green:223/255.0 blue:154/255.0 alpha:1.0]; // 保持强调色不变
+    self.selectionPreviewLabel.textColor = DYYYAccentColor();
     self.selectionPreviewLabel.textAlignment = NSTextAlignmentCenter;
     self.selectionPreviewLabel.numberOfLines = 2;
     self.selectionPreviewLabel.font = [UIFont systemFontOfSize:16];
-    self.selectionPreviewLabel.backgroundColor = isDarkMode ?
-        [UIColor colorWithRed:45/255.0 green:45/255.0 blue:45/255.0 alpha:1.0] :
-        [UIColor colorWithRed:245/255.0 green:245/255.0 blue:245/255.0 alpha:1.0];
+    self.selectionPreviewLabel.backgroundColor = DYYYColor(
+        [UIColor colorWithRed:45/255.0 green:45/255.0 blue:45/255.0 alpha:1.0],
+        [UIColor colorWithRed:245/255.0 green:245/255.0 blue:245/255.0 alpha:1.0],
+        self.darkMode);
     self.selectionPreviewLabel.layer.cornerRadius = 8;
     self.selectionPreviewLabel.layer.masksToBounds = YES;
     [self.contentView addSubview:self.selectionPreviewLabel];
 
     // 字符滚动视图 - 根据模式设置背景色
     self.charactersScrollView = [[UIScrollView alloc] initWithFrame:CGRectMake(20, 114, 260, 220)];
-    self.charactersScrollView.backgroundColor = isDarkMode ?
-        [UIColor colorWithRed:45/255.0 green:45/255.0 blue:45/255.0 alpha:1.0] :
-        [UIColor colorWithRed:245/255.0 green:245/255.0 blue:245/255.0 alpha:1.0];
+    self.charactersScrollView.backgroundColor = DYYYColor(
+        [UIColor colorWithRed:45/255.0 green:45/255.0 blue:45/255.0 alpha:1.0],
+        [UIColor colorWithRed:245/255.0 green:245/255.0 blue:245/255.0 alpha:1.0],
+        self.darkMode);
     self.charactersScrollView.layer.cornerRadius = 8;
     self.charactersScrollView.bounces = YES;
     self.charactersScrollView.showsVerticalScrollIndicator = YES;
@@ -106,9 +129,10 @@
 
     // 添加内容和按钮之间的分割线 - 根据模式设置颜色
     UIView *contentButtonSeparator = [[UIView alloc] initWithFrame:CGRectMake(0, 344, 300, 0.5)];
-    contentButtonSeparator.backgroundColor = isDarkMode ?
-        [UIColor colorWithRed:60/255.0 green:60/255.0 blue:60/255.0 alpha:1.0] :
-        [UIColor colorWithRed:230/255.0 green:230/255.0 blue:230/255.0 alpha:1.0];
+    contentButtonSeparator.backgroundColor = DYYYColor(
+        [UIColor colorWithRed:60/255.0 green:60/255.0 blue:60/255.0 alpha:1.0],
+        [UIColor colorWithRed:230/255.0 green:230/255.0 blue:230/255.0 alpha:1.0],
+        self.darkMode);
     [self.contentView addSubview:contentButtonSeparator];
 
     // 按钮容器
@@ -120,18 +144,20 @@
     self.cancelButton.frame = CGRectMake(0, 0, 149.5, 55.5);
     self.cancelButton.backgroundColor = [UIColor clearColor];
     [self.cancelButton setTitle:@"取消" forState:UIControlStateNormal];
-    [self.cancelButton setTitleColor:isDarkMode ?
-        [UIColor colorWithRed:160/255.0 green:160/255.0 blue:165/255.0 alpha:1.0] :
-        [UIColor colorWithRed:124/255.0 green:124/255.0 blue:130/255.0 alpha:1.0]
+    [self.cancelButton setTitleColor:DYYYColor(
+        [UIColor colorWithRed:160/255.0 green:160/255.0 blue:165/255.0 alpha:1.0],
+        [UIColor colorWithRed:124/255.0 green:124/255.0 blue:130/255.0 alpha:1.0],
+        self.darkMode)
         forState:UIControlStateNormal];
     [self.cancelButton addTarget:self action:@selector(cancelTapped) forControlEvents:UIControlEventTouchUpInside];
     [buttonContainer addSubview:self.cancelButton];
 
     // 按钮之间的分割线 - 根据模式设置颜色
     UIView *buttonSeparator = [[UIView alloc] initWithFrame:CGRectMake(149.5, 0, 0.5, 55.5)];
-    buttonSeparator.backgroundColor = isDarkMode ?
-        [UIColor colorWithRed:60/255.0 green:60/255.0 blue:60/255.0 alpha:1.0] :
-        [UIColor colorWithRed:230/255.0 green:230/255.0 blue:230/255.0 alpha:1.0];
+    buttonSeparator.backgroundColor = DYYYColor(
+        [UIColor colorWithRed:60/255.0 green:60/255.0 blue:60/255.0 alpha:1.0],
+        [UIColor colorWithRed:230/255.0 green:230/255.0 blue:230/255.0 alpha:1.0],
+        self.darkMode);
     [buttonContainer addSubview:buttonSeparator];
 
     // 确认按钮 - 根据模式设置文本颜色
@@ -139,9 +165,10 @@
     self.confirmButton.frame = CGRectMake(150, 0, 150, 55.5);
     self.confirmButton.backgroundColor = [UIColor clearColor];
     [self.confirmButton setTitle:@"确定" forState:UIControlStateNormal];
-    [self.confirmButton setTitleColor:isDarkMode ?
-        [UIColor colorWithRed:230/255.0 green:230/255.0 blue:235/255.0 alpha:1.0] :
-        [UIColor colorWithRed:45/255.0 green:47/255.0 blue:56/255.0 alpha:1.0]
+    [self.confirmButton setTitleColor:DYYYColor(
+        [UIColor colorWithRed:230/255.0 green:230/255.0 blue:235/255.0 alpha:1.0],
+        [UIColor colorWithRed:45/255.0 green:47/255.0 blue:56/255.0 alpha:1.0],
+        self.darkMode)
         forState:UIControlStateNormal];
     [self.confirmButton addTarget:self action:@selector(confirmTapped) forControlEvents:UIControlEventTouchUpInside];
     [buttonContainer addSubview:self.confirmButton];
@@ -157,27 +184,29 @@
 }
 
 - (void)setupCharacterButtons {
-  const CGFloat buttonSize = 25.0;
-  const CGFloat margin = 1.0;
-  const int buttonsPerRow = 10;
+  const CGFloat buttonSize = kDYYYButtonSize;
+  const CGFloat margin = kDYYYButtonMargin;
+  const int buttonsPerRow = kDYYYButtonsPerRow;
   
-  int row = 0;
-  int col = 0;
-  
-  BOOL isDarkMode = [DYYYManager isDarkMode];
-  UIColor *buttonBackgroundColor = isDarkMode ?
-      [UIColor colorWithRed:50/255.0 green:50/255.0 blue:50/255.0 alpha:1.0] :
-      [UIColor whiteColor];
-  UIColor *buttonTextColor = isDarkMode ?
-      [UIColor colorWithRed:230/255.0 green:230/255.0 blue:235/255.0 alpha:1.0] :
-      [UIColor colorWithRed:45/255.0 green:47/255.0 blue:56/255.0 alpha:1.0];
-  UIColor *buttonBorderColor = isDarkMode ?
-      [UIColor colorWithRed:70/255.0 green:70/255.0 blue:70/255.0 alpha:1.0] :
-      [UIColor colorWithRed:230/255.0 green:230/255.0 blue:230/255.0 alpha:1.0];
+  UIColor *buttonBackgroundColor = DYYYColor(
+      [UIColor colorWithRed:50/255.0 green:50/255.0 blue:50/255.0 alpha:1.0],
+      [UIColor whiteColor],
+      self.darkMode);
+  UIColor *buttonTextColor = DYYYColor(
+      [UIColor colorWithRed:230/255.0 green:230/255.0 blue:235/255.0 alpha:1.0],
+      [UIColor colorWithRed:45/255.0 green:47/255.0 blue:56/255.0 alpha:1.0],
+      self.darkMode);
+  UIColor *buttonBorderColor = DYYYColor(
+      [UIColor colorWithRed:70/255.0 green:70/255.0 blue:70/255.0 alpha:1.0],
+      [UIColor colorWithRed:230/255.0 green:230/255.0 blue:230/255.0 alpha:1.0],
+      self.darkMode);
   
   for (NSInteger i = 0; i < self.text.length; i++) {
     NSString *character = [self.text substringWithRange:NSMakeRange(i, 1)];
-    
+
+    NSInteger row = i / buttonsPerRow;
+    NSInteger col = i % buttonsPerRow;
+
     // 创建字符按钮 - 根据模式设置颜色
     UIButton *button = [UIButton buttonWithType:UIButtonTypeSystem];
     button.frame = CGRectMake(col * (buttonSize + margin), row * (buttonSize + margin), buttonSize, buttonSize);
@@ -191,107 +220,109 @@
     
     // 添加触摸事件
     [button addTarget:self action:@selector(characterTouchDown:) forControlEvents:UIControlEventTouchDown];
-    [button addTarget:self action:@selector(characterTouchMoved:withEvent:) forControlEvents:UIControlEventTouchDragInside | UIControlEventTouchDragEnter | UIControlEventTouchDragExit];
+    [button addTarget:self
+                   action:@selector(characterTouchMoved:withEvent:)
+         forControlEvents:UIControlEventTouchDragInside |
+                          UIControlEventTouchDragEnter |
+                          UIControlEventTouchDragExit |
+                          UIControlEventTouchDragOutside];
     [button addTarget:self action:@selector(characterTouchUp:) forControlEvents:UIControlEventTouchUpInside | UIControlEventTouchUpOutside | UIControlEventTouchCancel];
     
     [self.charactersScrollView addSubview:button];
     [self.characterButtons addObject:button];
     
-    // 更新行列位置
-    col++;
-    if (col >= buttonsPerRow) {
-      col = 0;
-      row++;
-    }
   }
-  
-  // 设置滚动视图的内容大小
-  CGFloat contentHeight = (row + (col > 0 ? 1 : 0)) * (buttonSize + margin) + 10; // 底部增加一点边距
-  self.charactersScrollView.contentSize = CGSizeMake(self.charactersScrollView.frame.size.width, MAX(contentHeight, self.charactersScrollView.frame.size.height));
+
+  NSInteger rows = (self.text.length + buttonsPerRow - 1) / buttonsPerRow;
+  CGFloat contentHeight = rows * (buttonSize + margin) + 10; // 底部增加一点边距
+  self.charactersScrollView.contentSize = CGSizeMake(self.charactersScrollView.frame.size.width,
+                                                    MAX(contentHeight, self.charactersScrollView.frame.size.height));
 }
 
 #pragma mark - Button Selection Handling
 
 - (void)characterTouchMoved:(UIButton *)sender withEvent:(UIEvent *)event {
-    // 确保已经开始选择
-    if (self.isSelecting) {
-        // 获取当前触摸点
-        UITouch *touch = [[event touchesForView:sender] anyObject];
-        CGPoint currentPoint = [touch locationInView:self.charactersScrollView];
-        
-        // 查找当前触摸点下的按钮
-        for (UIButton *button in self.characterButtons) {
-            if (CGRectContainsPoint(button.frame, currentPoint)) {
-                // 如果找到按钮，更新结束索引
-                NSInteger buttonTag = button.tag;
-                if (buttonTag != self.endIndex) {
-                    self.endIndex = buttonTag;
-                    [self updateSelectionWithStartIndex:self.startIndex endIndex:self.endIndex];
-                    
-                    // 自动滚动到可见区域
-                    [self scrollToVisibleButton:button];
-                }
-                break;
-            }
-        }
+  if (!self.isDragging) {
+    self.isDragging = YES;
+
+    if (self.selectedRange.location != NSNotFound) {
+      [self resetSelection];
+      self.isSelecting = YES;
+      self.startIndex = self.touchDownIndex;
+      self.endIndex = self.touchDownIndex;
+      [self updateSelectionWithStartIndex:self.startIndex endIndex:self.endIndex];
     }
+  }
+
+  if (self.isSelecting) {
+    UITouch *touch = [[event allTouches] anyObject];
+    CGPoint currentPoint = [touch locationInView:self.charactersScrollView];
+    currentPoint.y += self.charactersScrollView.contentOffset.y;
+
+    NSInteger col = floor(currentPoint.x / (kDYYYButtonSize + kDYYYButtonMargin));
+    NSInteger row = floor(currentPoint.y / (kDYYYButtonSize + kDYYYButtonMargin));
+    NSInteger index = row * kDYYYButtonsPerRow + col;
+
+    if (index >= 0 && index < self.characterButtons.count && index != self.endIndex) {
+      self.endIndex = index;
+      [self updateSelectionWithStartIndex:self.startIndex endIndex:self.endIndex];
+      [self scrollToVisibleButton:self.characterButtons[index]];
+    }
+  }
 }
 
 - (void)characterTouchDown:(UIButton *)sender {
-    NSInteger buttonTag = sender.tag;
-    
-    // 检查是否已有选择
-    if (self.isSelecting && self.startIndex != -1 && self.endIndex != -1) {
-        NSInteger startIndex = MIN(self.startIndex, self.endIndex);
-        NSInteger endIndex = MAX(self.startIndex, self.endIndex);
-        
-        // 1. 检查是否点击了已选中的字符
-        if (buttonTag >= startIndex && buttonTag <= endIndex) {
-            // 2. 处理点击已选中字符的情况
-            if (buttonTag == startIndex && buttonTag == endIndex) {
-                // 点击的是唯一选中的字符，取消整个选择
-                [self resetSelection];
-                return;
-            } else if (buttonTag == startIndex) {
-                // 点击的是选择范围的第一个字符
-                self.startIndex = startIndex + 1;
-            } else if (buttonTag == endIndex) {
-                // 点击的是选择范围的最后一个字符
-                self.endIndex = endIndex - 1;
-            } else {
-                // 点击的是选择范围中间的字符
-                // 选择较短的那一边进行调整
-                if (buttonTag - startIndex <= endIndex - buttonTag) {
-                    // 左侧部分较短，保留右侧部分
-                    self.startIndex = buttonTag + 1;
-                } else {
-                    // 右侧部分较短，保留左侧部分
-                    self.endIndex = buttonTag - 1;
-                }
-            }
-            
-            // 更新选择范围
-            if (self.startIndex > self.endIndex) {
-                // 如果结果是无效的选择范围，则重置选择
-                [self resetSelection];
-            } else {
-                [self updateSelectionWithStartIndex:self.startIndex endIndex:self.endIndex];
-            }
-            return;
-        }
-    }
-    
-    // 原有的处理逻辑
-    if (!self.isSelecting || (self.startIndex == -1 && self.endIndex == -1)) {
+    NSInteger idx = sender.tag;
+
+    self.touchDownIndex = idx;
+    self.startIndex = idx;
+    self.endIndex = idx;
+    self.isDragging = NO;
+
+    if (self.selectedRange.location == NSNotFound) {
         self.isSelecting = YES;
-        self.startIndex = buttonTag;
-        self.endIndex = buttonTag;
-    } else {
-        // 已有选择，扩展选择范围
-        self.endIndex = buttonTag;
+        [self updateSelectionWithStartIndex:self.startIndex endIndex:self.endIndex];
+        return;
     }
-    
-    [self updateSelectionWithStartIndex:self.startIndex endIndex:self.endIndex];
+
+    NSInteger rangeStart = self.selectedRange.location;
+    NSInteger rangeEnd = NSMaxRange(self.selectedRange) - 1;
+
+    if (idx >= rangeStart && idx <= rangeEnd) {
+        if (rangeStart == rangeEnd) {
+            [self resetSelection];
+            return;
+        } else if (idx == rangeStart) {
+            rangeStart++;
+        } else if (idx == rangeEnd) {
+            rangeEnd--;
+        } else {
+            if (idx - rangeStart <= rangeEnd - idx) {
+                rangeStart = idx + 1;
+            } else {
+                rangeEnd = idx - 1;
+            }
+        }
+
+        if (rangeStart <= rangeEnd) {
+            self.isSelecting = YES;
+            self.startIndex = rangeStart;
+            self.endIndex = rangeEnd;
+            [self updateSelectionWithStartIndex:self.startIndex endIndex:self.endIndex];
+        } else {
+            [self resetSelection];
+        }
+    } else {
+        self.isSelecting = YES;
+        if (idx < rangeStart) {
+            self.startIndex = idx;
+            self.endIndex = rangeEnd;
+        } else {
+            self.startIndex = rangeStart;
+            self.endIndex = idx;
+        }
+        [self updateSelectionWithStartIndex:self.startIndex endIndex:self.endIndex];
+    }
 }
 
 // 添加新方法实现自动滚动
@@ -319,20 +350,23 @@
 }
 
 - (void)characterTouchUp:(UIButton *)sender {
-    // 不再重置isSelecting状态，这样可以保持选择状态以便单击扩展选择
+    self.isDragging = NO;
 }
 
 // 添加方法重置选择状态
 - (void)resetSelection {
     self.isSelecting = NO;
+    self.isDragging = NO;
     self.startIndex = -1;
     self.endIndex = -1;
     self.selectedText = [NSMutableString string];
+    self.touchDownIndex = -1;
+    self.selectedRange = NSMakeRange(NSNotFound, 0);
     
-    BOOL isDarkMode = [DYYYManager isDarkMode];
-    UIColor *buttonBackgroundColor = isDarkMode ?
-        [UIColor colorWithRed:50/255.0 green:50/255.0 blue:50/255.0 alpha:1.0] :
-        [UIColor whiteColor];
+    UIColor *buttonBackgroundColor = DYYYColor(
+        [UIColor colorWithRed:50/255.0 green:50/255.0 blue:50/255.0 alpha:1.0],
+        [UIColor whiteColor],
+        self.darkMode);
     
     for (UIButton *button in self.characterButtons) {
         button.backgroundColor = buttonBackgroundColor;
@@ -342,37 +376,38 @@
 }
 
 - (void)updateSelectionWithStartIndex:(NSInteger)startIdx endIndex:(NSInteger)endIdx {
-  // 确保有效的开始和结束索引
   NSInteger startIndex = MIN(startIdx, endIdx);
   NSInteger endIndex = MAX(startIdx, endIdx);
-  
-  BOOL isDarkMode = [DYYYManager isDarkMode];
-  UIColor *buttonBackgroundColor = isDarkMode ?
-      [UIColor colorWithRed:50/255.0 green:50/255.0 blue:50/255.0 alpha:1.0] :
-      [UIColor whiteColor];
-  
-  // 清除所有按钮选中状态
-  for (UIButton *button in self.characterButtons) {
-    button.backgroundColor = buttonBackgroundColor;
-  }
-  
-  // 设置选中范围内按钮的状态
-  NSMutableString *selection = [NSMutableString string];
-  for (NSInteger i = startIndex; i <= endIndex; i++) {
-    if (i < self.characterButtons.count) {
-      UIButton *button = self.characterButtons[i];
-      button.backgroundColor = [UIColor colorWithRed:11/255.0 green:223/255.0 blue:154/255.0 alpha:0.2]; // 浅绿色背景，保持一致
-      [selection appendString:button.titleLabel.text];
+
+  UIColor *buttonBackgroundColor = DYYYColor(
+      [UIColor colorWithRed:50 / 255.0 green:50 / 255.0 blue:50 / 255.0 alpha:1.0],
+      [UIColor whiteColor],
+      self.darkMode);
+
+  NSRange newRange = NSMakeRange(startIndex, endIndex - startIndex + 1);
+  NSRange oldRange = self.selectedRange.location == NSNotFound ? NSMakeRange(0, 0) : self.selectedRange;
+
+  // 取消旧范围中不再选中的按钮
+  NSInteger oldEnd = NSMaxRange(oldRange) - 1;
+  for (NSInteger i = oldRange.location; i <= oldEnd; i++) {
+    if (i < 0 || i >= self.characterButtons.count) continue;
+    if (i < newRange.location || i >= NSMaxRange(newRange)) {
+      self.characterButtons[i].backgroundColor = buttonBackgroundColor;
     }
   }
-  
-  // 更新选中文本和预览标签
-  self.selectedText = selection;
-  if (selection.length > 0) {
-    self.selectionPreviewLabel.text = selection;
-  } else {
-    self.selectionPreviewLabel.text = @"请滑动选择文字";
+
+  // 选中新范围
+  NSMutableString *selection = [NSMutableString string];
+  for (NSInteger i = newRange.location; i < NSMaxRange(newRange); i++) {
+    if (i < 0 || i >= self.characterButtons.count) continue;
+    UIButton *button = self.characterButtons[i];
+    button.backgroundColor = [DYYYAccentColor() colorWithAlphaComponent:0.2];
+    [selection appendString:button.titleLabel.text];
   }
+
+  self.selectedRange = newRange;
+  self.selectedText = selection;
+  self.selectionPreviewLabel.text = selection.length > 0 ? selection : @"请滑动选择文字";
 }
 
 #pragma mark - Show/Dismiss Methods


### PR DESCRIPTION
## Summary
- ensure drag events keep firing while finger is outside initial button
- look up touch from all events and adjust for scroll offset
- add helpers for dark mode color handling
- improve drag and tap selection logic

## Testing
- `make` *(fails: `/tweak.mk: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_b_684a3c16752083319eac65934e7dd70a